### PR TITLE
styled SongTable

### DIFF
--- a/src/app/features/catalogue/components/playlist-dashboard/song-table/song-table.component.css
+++ b/src/app/features/catalogue/components/playlist-dashboard/song-table/song-table.component.css
@@ -4,16 +4,45 @@
 }
 
 table {
-  border-spacing: 0 1rem;
+  border-collapse: collapse;
   text-align: left;
   width: 100%;
 
-  th,
-  td {
-    padding-right: 0.5rem;
+  & tr:nth-child(odd) {
+    background-color: var(--palette-content);
   }
 }
 
-.thumbnail-col {
-  text-align: center;
+th {
+  background-color: var(--palette-bg-darker);
+  border-bottom: 0.25rem solid var(--palette-accent);
+  padding-bottom: 1rem;
+  padding-top: 1rem;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+tr,
+thead {
+  & > :first-child,
+  :last-child {
+    text-align: center;
+  }
+
+  & > :last-child {
+    padding-right: 1rem;
+  }
+}
+
+tr > td:first-child {
+  height: 6rem;
+  width: 6rem;
+
+  & img {
+    height: auto;
+    max-height: 5rem;
+    max-width: 5rem;
+    width: auto;
+  }
 }

--- a/src/app/features/catalogue/components/playlist-dashboard/song-table/song-table.component.html
+++ b/src/app/features/catalogue/components/playlist-dashboard/song-table/song-table.component.html
@@ -1,6 +1,6 @@
 <table>
   <thead>
-    <th class="thumbnail-col">Song</th>
+    <th>Song</th>
     <th>Title</th>
     <th>Artist</th>
     <th></th>
@@ -8,14 +8,19 @@
   <tbody>
     @for (song of songs; track song) {
       <tr>
-        <td class="thumbnail-col">
+        <td>
           <a href="{{ song.url }}" target="_blank">
-            <img
-              class="{{ song.thumbnail_url ? '' : 'adaptive-img' }}"
-              src="{{ song.thumbnail_url ? song.thumbnail_url : 'vinyl.png' }}"
-              alt="thumbnail"
-              width="64"
-            />
+            @if (song.thumbnail_url) {
+              <img src="{{ song.thumbnail_url }}" alt="thumbnail" />
+            } @else {
+              <img
+                class="adaptive-filter"
+                ngSrc="vinyl.png"
+                alt="thumbnail"
+                height="512"
+                width="512"
+              />
+            }
           </a>
         </td>
         <td>

--- a/src/app/features/catalogue/components/playlist-dashboard/song-table/song-table.component.ts
+++ b/src/app/features/catalogue/components/playlist-dashboard/song-table/song-table.component.ts
@@ -1,10 +1,12 @@
 import { Component, EventEmitter, Input, Output } from "@angular/core";
 import { PlaylistSong } from "../../../../../core/catalogue/models/playlist-song";
+import { NgOptimizedImage } from "@angular/common";
 
 @Component({
   selector: "app-song-table",
   templateUrl: "./song-table.component.html",
   styleUrl: "./song-table.component.css",
+  imports: [NgOptimizedImage],
 })
 export class SongTableComponent {
   @Input({ required: true })


### PR DESCRIPTION
Refreshed the look and feel of the SongTable component to bring it on par with the other components.

[fixes]
- placeholder 'vinyl' img not reacting to system theme preferences. Caused by dynamically setting the class name, which lead to it not being picked up as a refactor target when changing that class name during development.
- table 'flickering' on image load. Caused by not specifying the height & width to be reserved for the image, caused in turn by an inability to do so due to Song thumbnails having inconsistent aspect ratios as they come from various vendors. The solution was to not set the height & width of the image itself, but the container it was in and give it a max height that keeps it within the container (td).

[removals]
- 'thumbnail-col' CSS class. Favouring leveraging CSS selectors as far as possible.

[additions]
- added sticky table header. Ensures the header information is visible when scrolling.
- added row striping. Required to make reading the table visually consistent. Without striping, the varying heights of the thumbnails caused by differing aspect ratios, as well as the possible wrapping of title text to the next line, makes it hard to quickly separate the content in each row. A stripe is visually pleasing and masks this problem.